### PR TITLE
ログイン中のユーザーの投稿だけを一覧表示できるようにした

### DIFF
--- a/app/controllers/users/posts_controller.rb
+++ b/app/controllers/users/posts_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Users::PostsController < ApplicationController
+  before_action :correct_user, only: [:index]
+  def index
+    @posts = current_user.posts
+  end
+
+  private
+
+  def correct_user
+    @user = User.find(params[:user_id])
+    redirect_to(posts_path) unless current_user?(@user)
+  end
+
+  def current_user?(user)
+    user == current_user
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
+  has_many :posts, dependent: :destroy
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -37,7 +37,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "更新する" %>
   </div>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,8 @@
   <p class="navbar-text pull-right">
     <% if user_signed_in? %>
       <strong><%= current_user.name %></strong>
+      <%= link_to 'みんなの投稿一覧', posts_path, class: 'navbar-link' %> |
+      <%= link_to '自分の投稿一覧', user_posts_path(current_user), class: 'navbar-link' %> |
       <%= link_to 'ユーザー一覧', users_path, class: 'navbar-link' %> |
       <%= link_to '登録情報', user_path(current_user), class: 'navbar-link' %> |
       <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'navbar-link'  %>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -1,0 +1,14 @@
+<p style="color: green"><%= notice %></p>
+
+<h1>Posts</h1>
+
+<div id="posts">
+  <% @posts.each do |post| %>
+      <%= render 'posts/post', post: post %>
+    <p>
+      <%= link_to "Show this post", post %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New post", new_post_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :users, only: [:index, :show]
+  resources :users, only: [:index, :show] do
+    resources :posts, only: [:index], controller: "users/posts"
+  end
   resources :posts
   resources :reactions
 end


### PR DESCRIPTION
# issue
#17 

# 概要
- ログイン中のユーザーの投稿だけを一覧で表示するページを追加した。
  - ユーザーごとの投稿一覧はそのユーザーがログインしているときしか見られない。
- メニューに「みんなの投稿一覧」「自分の投稿一覧」を追加した。

# スクリーンショット
<img width="664" alt="image" src="https://github.com/monyatto/erasugi/assets/83024928/f01001f3-c5e1-4541-b9d6-277565d89a4e">

