### PR TITLE
一覧に表示される投稿を変更

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,8 @@ class PostsController < ApplicationController
 
   # GET /posts or /posts.json
   def index
-    @posts = Post.all
+    one_week_ago = Time.current.advance(weeks: -1)
+    @posts = Post.where('created_at > ?', one_week_ago).order('RANDOM()')
   end
 
   # GET /posts/1 or /posts/1.json

--- a/app/controllers/users/posts_controller.rb
+++ b/app/controllers/users/posts_controller.rb
@@ -3,7 +3,7 @@
 class Users::PostsController < ApplicationController
   before_action :correct_user, only: [:index]
   def index
-    @posts = current_user.posts
+    @posts = current_user.posts.order(created_at: :desc)
   end
 
   private


### PR DESCRIPTION
# Issue
#63

# 概要
- 「みんなの投稿一覧」では1週間以内の投稿がランダムな順番で表示
-  「自分の投稿一覧」では全ての投稿が新しい順で表示