### PR TITLE
新規投稿フォームをモーダル化した

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,7 +29,6 @@ class PostsController < ApplicationController
     @reactions_types = ReactionsType.all
     respond_to do |format|
       if @post.save
-        # format.turbo_stream { flash.now[:notice] = '投稿成功時のメッセージ' }
         format.html { redirect_to post_url(@post), notice: 'えらすぎを投稿しました' }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/views/layouts/_modal.html.erb
+++ b/app/views/layouts/_modal.html.erb
@@ -1,0 +1,12 @@
+<button class="btn" onclick="my_modal_2.showModal()">＋</button>
+  <dialog id="my_modal_2" class="modal">
+    <div class="modal-box">
+      <form method="dialog">
+        <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+      </form>
+      <%= yield %>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button>close</button>
+    </form>
+  </dialog>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,5 +42,6 @@
   </div>
   <%= yield %>
 </div>
+<%= render "posts/new" %>
 </body>
 </html>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,22 +1,9 @@
 <%= form_with(model: post) do |form| %>
-  <% if @post.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(@post.errors.count, "error") %> prohibited this post from being saved:</h2>
-
-      <ul>
-        <% @post.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-  <div>
+   <div>
     <%= form.label :content, style: "display: block" %>
     <%= form.text_area :content %>
   </div>
-
   <div>
     <%= form.submit class:"btn" %>
-    <%= link_to "キャンセル", @post, class: "btn" %>
   </div>
 <% end %>

--- a/app/views/posts/_new.html.erb
+++ b/app/views/posts/_new.html.erb
@@ -1,0 +1,5 @@
+<div class="absolute right-20 bottom-20">
+<%= render "layouts/modal", title: "登録" do %>
+  <%= render "posts/form", post: Post.new, class: "textarea textarea-bordered" %>
+<% end %>
+</div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,0 @@
-<h1>新規投稿</h1>
-<%= render "form", post: @post, class: "textarea textarea-bordered" %>
-<br>
-<div>
-  <%= link_to "戻る", posts_path, class: "link" %>
-</div>

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -3,6 +3,3 @@
     <%= render @posts %>
   </div>
 </div>
-<div class="flex justify-center">
-  <%= link_to "新規投稿", new_post_path, class: "link" %>
-</div>


### PR DESCRIPTION
# Issue
- #78 

# 概要
新規投稿ボタンをモーダル化して、どのページからでもアクセスできるようにした。

# スクリーンショット
<img width="653" alt="image" src="https://github.com/monyatto/erasugi/assets/83024928/3a310bdc-b40e-40f7-af1f-87d16cc82e86">

<img width="684" alt="image" src="https://github.com/monyatto/erasugi/assets/83024928/95132ef9-d1e4-4ff1-9aba-02468685eca8">