### PR TITLE
リアクションの最大表示数を制限

### DIFF
--- a/app/javascript/controllers/reaction_controller.js
+++ b/app/javascript/controllers/reaction_controller.js
@@ -129,6 +129,9 @@ export default class extends Controller {
             frameIndex: 0
         });
         this.layer.add(sprite);
+        if (this.layer.children.length > 100) {
+            this.layer.children[0].destroy();
+        }
         sprite.start();
         sprite.moveToTop();
         this.layer.draw();

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,8 +12,8 @@ class Post < ApplicationRecord
   end
 
   def associated_reaction_type_ids
-    reactions.map do |reaction|
-      ReactionsType.find(reaction.reactions_type_id).id
+    reactions.includes(:reactions_type).order(created_at: :desc).limit(100).sort_by(&:created_at).map do |reaction|
+      reaction.reactions_type.id
     end
   end
 end


### PR DESCRIPTION
# Issue
- #47
 
# 概要
リアクションの最大表示数を100件までにした。
既に押されたリアクションを表示するのは最新100件のみで、新しくリアクションが押された場合は古いリアクションから削除するようにした。