### PR TITLE
バリデーションエラー時も残り文字数を正確に表示するようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,6 @@ group :development do
   gem 'rubocop-rails', require: false
 end
 
-
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 module PostsHelper
+  def form_character_count(post)
+    content_length = post.content&.length.to_i
+    content_length > 140 ? "#{content_length - 140}文字オーバーです" : "残り#{140 - content_length}文字入力できます"
+  end
 end

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -12,9 +12,9 @@
     <% end %>
     <div class="flex space-x-1">
       <%= form.text_field :content %>
-      <%= form.submit class:"btn" %>
+      <%= form.submit "更新する", class: "btn" %>
     </div>
-    <p id="text-length"><%="残り#{140 - (@post.content&.length || 0)}文字入力できます" %></p>
+    <p id="text-length"><%= form_character_count(@post) %></p>
   <% end %>
 </div>
 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -10,12 +10,12 @@
       </div>
     <% end %>
     <div>
-      <%= form.label :content, style: "display: block" %>
+      <%= form.label :あたらしいえらすぎ, style: "display: block" %>
       <%= form.text_area :content %>
-      <p id="text-length"><%="残り#{140 - (@post.content&.length || 0)}文字入力できます" %></p>
+      <p id="text-length"><%= form_character_count(@post) %></p>
     </div>
     <div>
-      <%= form.submit "Submit", class: "btn" %>
+      <%= form.submit "投稿する", class: "btn" %>
     </div>
   <% end %>
 </div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -66,7 +66,7 @@ ja:
         instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
         instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
         instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
-        subject: パスワードの再設定について
+        subject: 【えらすぎ】パスワードの再設定について
       unlock_instructions:
         action: アカウントのロック解除
         greeting: "%{recipient}様"


### PR DESCRIPTION
# Issue
- #95 

# 概要
バリデーションエラー時に「残り-100文字入力できます」みたいになってしまうのを正確に表示されるようにした。