### PR TITLE
未ログインの場合、会員登録かログインを促す表示を追加

### DIFF
--- a/app/views/layouts/_unlogin.html.erb
+++ b/app/views/layouts/_unlogin.html.erb
@@ -1,0 +1,7 @@
+<div class="text-center">
+  <% if current_user.nil? %>
+    <p>会員登録すると過去の投稿が見れるようになります</p>
+    <%= button_to "新規登録", new_user_registration_path, method: :get, class: "btn" %>
+    <p><%= link_to '登録済みの方はログイン', new_user_session_path %></p>
+  <% end %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,3 +1,4 @@
+<%= render "layouts/unlogin" %>
 <div class="h-[100vh]">
 <div id="container" style="position: absolute;"></div>
   <div class="swiper" id="swiper_id"  data-controller="scroll" data-scroll-posts-ids-value='<%= @posts.pluck(:id) %>'>


### PR DESCRIPTION
# Issue
- #103

# 概要
未ログイン状態で投稿一覧ページにアクセスすると会員登録がログインを促す文言が表示されるようにした。

# スクリーンショット
<img width="826" alt="image" src="https://github.com/monyatto/erasugi/assets/83024928/c2effb9b-32e9-4c89-985a-97385a1e3047">
