### PR TITLE
ユーザーごとの投稿一覧ページに無限スクロールを実装した。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,5 @@ end
 gem 'tailwindcss-rails'
 
 gem 'jsbundling-rails'
+
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,18 @@ GEM
     jsbundling-rails (1.2.1)
       railties (>= 6.0.0)
     json (2.7.1)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
@@ -135,8 +147,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    meta-tags (2.20.0)
-      actionpack (>= 6.0.0, < 7.2)
     method_source (1.0.0)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
@@ -295,8 +305,8 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jsbundling-rails
+  kaminari
   letter_opener_web (~> 2.0)
-  meta-tags
   mini_magick
   pg (~> 1.1)
   public_uid

--- a/app/controllers/users/posts_controller.rb
+++ b/app/controllers/users/posts_controller.rb
@@ -4,7 +4,7 @@ class Users::PostsController < ApplicationController
   before_action :correct_user, only: %i[index]
 
   def index
-    @posts = current_user.posts.order(created_at: :desc)
+    @posts = current_user.posts.order(created_at: :desc).page(params[:page])
   end
 
   private

--- a/app/views/users/posts/index.html.erb
+++ b/app/views/users/posts/index.html.erb
@@ -1,6 +1,9 @@
 <% if @posts.count > 0 %>
   <div class="pt-[8vh]" id="posts">
-    <%= render @posts %>
+    <%= turbo_frame_tag "posts-page-#{@posts.current_page}" do %>
+      <%= render @posts %>
+      <%= turbo_frame_tag "posts-page-#{@posts.next_page}", loading: :lazy, src: path_to_next_page(@posts) %>
+    <% end %>
   </div>
 <% else %>
   <div class="h-[80vh] flex flex-col justify-center items-center">

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 15
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/kaminari.ja.yml
+++ b/config/locales/kaminari.ja.yml
@@ -1,0 +1,17 @@
+ja:
+  helpers:
+    page_entries_info:
+      more_pages:
+        display_entries: "<b>%{total}</b>中の%{entry_name}を表示しています <b>%{first} - %{last}</b>"
+      one_page:
+        display_entries:
+          one: "<b>%{count}</b>レコード表示中です %{entry_name}"
+          other: "<b>%{count}</b>レコード表示中です %{entry_name}"
+          zero: "レコードが見つかりませんでした %{entry_name}"
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      next: "次 &rsaquo;"
+      previous: "&lsaquo; 前"
+      truncate: "&hellip;"


### PR DESCRIPTION
# Issue
- #142

# 概要
ユーザーごとの投稿一覧ページにページネーションを追加し、スクロールされると次のページが表示されるようにした。