### PR TITLE
登録情報ページでメールアドレスが長い場合のデザインを修正した

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,13 +5,15 @@
 
 <div class="h-[80svh] flex flex-col justify-center items-center space-y-4">
   <h2 class="text-xl">登録情報</h2>
-<p>
-  <strong>メールアドレス: </strong>
-  <%= @user.email %>
-</p>
-<p>
-  <strong>ユーザー名:</strong>
-  <%= @user.name %>
-</p>
-<p class="pt-4"><%= link_to '登録情報を変更する', edit_user_registration_path, class: "underline" %></p>
+  <dl class="space-y-2">
+    <div class="flex flex-col items-center px-4">
+      <dt>メールアドレス</dt>
+      <dd class="break-all"><%= @user.email %></dd>
+    </div>
+    <div class="flex flex-col items-center">
+      <dt>ユーザー名</dt>
+      <dd><%= @user.name %></dd>
+    </div>
+  </dl>
+  <p class="pt-2"><%= link_to '登録情報を変更する', edit_user_registration_path, class: "underline" %></p>
 </div>

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -28,8 +28,8 @@ class UsersTest < ApplicationSystemTestCase
     visit root_path
     find('.hamburger').click
     click_on '登録情報'
-    assert_text "#{@user.email}"
-    assert_text "#{@user.name}"
+    assert_text @user.email.to_s
+    assert_text @user.name.to_s
   end
 
   test 'create user' do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -28,8 +28,8 @@ class UsersTest < ApplicationSystemTestCase
     visit root_path
     find('.hamburger').click
     click_on '登録情報'
-    assert_text "メールアドレス: #{@user.email}"
-    assert_text "ユーザー名: #{@user.name}"
+    assert_text "#{@user.email}"
+    assert_text "#{@user.name}"
   end
 
   test 'create user' do
@@ -52,8 +52,8 @@ class UsersTest < ApplicationSystemTestCase
     assert_selector('#flash-message', text: 'アカウント情報を変更しました')
 
     visit user_path(@user.public_uid)
-    assert_text 'メールアドレス: change@example.com'
-    assert_text 'ユーザー名: テスト変更'
+    assert_text 'change@example.com'
+    assert_text 'テスト変更'
   end
 
   test 'delete user' do


### PR DESCRIPTION
# Issue
- #284 

# 概要
登録情報ページでメールアドレスが長い場合のデザインを修正した。

# スクリーンショット
## 変更前
<img width="373" alt="image" src="https://github.com/monyatto/erasugi/assets/83024928/98719e81-ba2f-4003-9376-ddab37339da4">

## 変更後
<img width="375" alt="image" src="https://github.com/monyatto/erasugi/assets/83024928/74b45cb3-ab39-437d-a80e-964b356dc93a">
