### PR TITLE
投稿一覧画面の余白を調整した

### DIFF
--- a/app/views/users/posts/_post.html.erb
+++ b/app/views/users/posts/_post.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "post_#{post.public_uid}", class: "flex flex-col mr-5 ml-5 mt-2 mb-2 p-4 pb-6  border border-stone-900 rounded-lg" do %>
+<%= turbo_frame_tag "post_#{post.public_uid}", class: "flex flex-col mr-5 ml-5 mt-2 mb-2 p-3 pb-4  border border-stone-900 rounded-lg" do %>
   <%= link_to post_path(post.public_uid), target: "_top", class: "flex flex-col" do %>
     <div class="flex items-center justify-between">
       <div class="ms-0">


### PR DESCRIPTION
# Issue
- #289

# 概要
投稿一覧画面の余白を調整した。

# スクリーンショット
## 変更前
<img width="371" alt="image" src="https://github.com/monyatto/erasugi/assets/83024928/6962c42d-d9bf-4b2c-859a-bdc08e834c4d">

## 変更後
<img width="375" alt="image" src="https://github.com/monyatto/erasugi/assets/83024928/f240691a-0248-46b7-84e6-f7e0c91b812b">
