### PR TITLE
「ログインを記憶する」のデザインを修正した

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -22,8 +22,8 @@
 
     <% if devise_mapping.rememberable? %>
       <div class="field flex justify-center items-center pt-2">
-        <%= f.check_box :remember_me %>
-        <%= f.label :remember_me %>
+        <%= f.check_box :remember_me, class: "rounded"%>
+        <%= f.label :remember_me, class: "ml-2"%>
       </div>
     <% end %>
 


### PR DESCRIPTION
# Issue
- #292 

# 概要
「ログインを記憶する」のデザインを修正した。

# スクリーンショット
## 変更前
<img width="374" alt="スクリーンショット 2024-05-28 15 31 42" src="https://github.com/monyatto/erasugi/assets/83024928/881c63cd-4e43-49fc-b33c-dcbc8412cb4e">

## 変更後
<img width="375" alt="image" src="https://github.com/monyatto/erasugi/assets/83024928/7959e2e0-d9aa-4e1b-9cd3-b0186cb8d001">
