### PR TITLE
残り文字数の上の余白を増やした

### DIFF
--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -15,7 +15,7 @@
       <% end %>
       <div class="flex flex-col justify-center items-center pb-4">
         <%= form.text_area :content, class: "block rounded-md h-[10svh] w-[36svh]" %>
-        <p class="text-sm" id="text-length"><%= count_characters(@post) %></p>
+        <p class="text-sm mt-2" id="text-length"><%= count_characters(@post) %></p>
       </div>
       <div class="flex justify-center gap-4 text-sm">
         <%= form.submit "更新する", class: "py-2 bg-gray-100 w-[16svh] rounded-md shadow-md cursor-pointer hover:bg-opacity-50" %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -20,7 +20,7 @@
       </div>
       <div class="flex flex-col justify-center items-center ">
         <%= form.text_area :content, placeholder: '午前中に起きた！', class: "block rounded-md h-[25svh] w-[40svh] placeholder-stone-400" %>
-        <p class="text-sm" id="text-length"><%= count_characters(@post) %></p>
+        <p class="text-sm mt-2" id="text-length"><%= count_characters(@post) %></p>
       </div>
       <div>
         <%= form.submit "投稿する", class: "py-2 bg-gray-100 w-[40svh] rounded-md shadow-md cursor-pointer hover:bg-opacity-50" %>


### PR DESCRIPTION
# Issue
- #297

# 概要
残り文字数の上の余白を増やした。

# スクリーンショット
## 変更前
<img width="371" alt="スクリーンショット 2024-05-29 12 25 17" src="https://github.com/monyatto/erasugi/assets/83024928/c40fe4be-8979-469d-9ba0-027b0c38cd53">

## 変更後
<img width="373" alt="image" src="https://github.com/monyatto/erasugi/assets/83024928/15e053ca-8dea-4c96-8de5-81c7ec12979a">
