### PR TITLE
config/environmentsの修正をした

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -96,7 +96,6 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   config.action_mailer.default_url_options = { host: 'erasugi.onrender.com'}
-  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
# Issue
- #325

# 概要
`config/environments/production.rb`を以下の内容で修正
- `config.force_ssl = true`を設定（rails7.1でデフォルトの設定になったので、実際には[railsのバージョンを7\.1\.3\.4にアップデートした by monyatto · Pull Request \#317 · monyatto/erasugi](https://github.com/monyatto/erasugi/pull/317)で変更）
- コメント文と重複していた`config.action_mailer.raise_delivery_errors`の記述を一つにした。