### PR TITLE
clipboard_controller.js周辺の修正をした

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -5,25 +5,7 @@ export default class extends Controller {
 
   copy(event) {
     event.preventDefault();
+    this.dispatch("copy");
     navigator.clipboard.writeText(this.urlTarget);
-    this.displayFlashMessage("URLをコピーしました");
-  }
-
-  displayFlashMessage(message) {
-    const flash = document.getElementById("flash");
-    const flashMessage = document.createElement("div");
-
-    flashMessage.innerText = message;
-    flashMessage.className =
-      "animate-disappear flex items-center justify-center bg-white fixed w-screen sm:w-[640px] animate-disappear";
-    flashMessage.dataset.controller = "removals";
-    flashMessage.dataset.action = "animationend->removals#remove";
-
-    flash.appendChild(flashMessage);
-    flash.style.display = "block";
-
-    flashMessage.addEventListener("animationend", function () {
-      flashMessage.style.display = "none";
-    });
   }
 }

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["flash", "message"];
+
+  displayMessage() {
+    const message = this.messageTarget;
+    const flash = this.flashTarget;
+
+    message.innerText = "URLをコピーしました";
+    message.className =
+      "animate-disappear flex items-center justify-center bg-white fixed w-screen sm:w-[640px] animate-disappear";
+
+    message.dataset.controller = "removal";
+    message.dataset.action = "animationend->removal#remove";
+
+    flash.appendChild(message);
+    flash.style.display = "block";
+  }
+}

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,21 +1,20 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static values = { text: { type: String } };
-  static targets = ["flash", "message"];
+  static targets = ["container", "element"];
 
-  displayMessage() {
-    const message = this.messageTarget;
-    const flash = this.flashTarget;
+  displayMessage({ params: { text } }) {
+    const flashContainer = this.containerTarget;
+    const flashElement = this.elementTarget;
 
-    message.innerText = this.textValue;
-    message.className =
+    flashElement.innerText = text;
+    flashElement.className =
       "animate-disappear flex items-center justify-center bg-white fixed w-screen sm:w-[640px] animate-disappear";
 
-    message.dataset.controller = "removal";
-    message.dataset.action = "animationend->removal#remove";
+    flashElement.dataset.controller = "removal";
+    flashElement.dataset.action = "animationend->removal#remove";
 
-    flash.appendChild(message);
-    flash.style.display = "block";
+    flashContainer.appendChild(flashElement);
+    flashContainer.style.display = "block";
   }
 }

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static values = {text: { type: String }};
+  static values = { text: { type: String } };
   static targets = ["flash", "message"];
 
   displayMessage() {

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,13 +1,14 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
+  static values = {text: { type: String }};
   static targets = ["flash", "message"];
 
   displayMessage() {
     const message = this.messageTarget;
     const flash = this.flashTarget;
 
-    message.innerText = "URLをコピーしました";
+    message.innerText = this.textValue;
     message.className =
       "animate-disappear flex items-center justify-center bg-white fixed w-screen sm:w-[640px] animate-disappear";
 

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,4 +1,4 @@
-<div id="flash" data-controller="flash" data-action="clipboard:copy@window->flash#displayMessage" data-flash-target="flash">
+<div id="flash" data-controller="flash" data-action="clipboard:copy@window->flash#displayMessage" data-flash-text-value="URLをコピーしました" data-flash-target="flash">
   <div id="flash-message" data-flash-target="message">
     <% flash.each do |flash_type, message| %>
       <% if flash_type == "notice" %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,5 +1,5 @@
-<div id="flash" data-controller="flash" data-action="clipboard:copy@window->flash#displayMessage" data-flash-text-value="URLをコピーしました" data-flash-target="flash">
-  <div id="flash-message" data-flash-target="message">
+<div id="flash" data-controller="flash" data-action="clipboard:copy@window->flash#displayMessage" data-flash-text-param="URLをコピーしました" data-flash-target="container">
+  <div id="flash-message" data-flash-target="element">
     <% flash.each do |flash_type, message| %>
       <% if flash_type == "notice" %>
         <div data-controller="removal" class="animate-disappear flex justify-center" data-action="animationend->removal#remove">

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,21 +1,23 @@
-<div id="flash-message">
-  <% flash.each do |flash_type, message| %>
-    <% if flash_type == "notice" %>
-      <div data-controller="removal" class="animate-disappear flex justify-center" data-action="animationend->removals#remove">
-        <div class="flex justify-center items-center bg-white bg-opacity-80 h-[8svh] px-4 fixed w-screen sm:w-[640px]">
-          <div class="p-[2svh] text-[#7FBE17]">
-            <%= message %>
+<div id="flash" data-controller="flash" data-action="clipboard:copy@window->flash#displayMessage" data-flash-target="flash">
+  <div id="flash-message" data-flash-target="message">
+    <% flash.each do |flash_type, message| %>
+      <% if flash_type == "notice" %>
+        <div data-controller="removal" class="animate-disappear flex justify-center" data-action="animationend->removal#remove">
+          <div class="flex justify-center items-center bg-white bg-opacity-80 h-[8svh] px-4 fixed w-screen sm:w-[640px]">
+            <div class="p-[2svh] text-[#7FBE17]">
+              <%= message %>
+            </div>
           </div>
         </div>
-      </div>
-    <% elsif flash_type == "alert" %>
-      <div class="flex justify-center">
-        <div class="flex justify-center items-center bg-white bg-opacity-80 h-[8svh] px-4 fixed w-screen sm:w-[640px]">
-          <div class="p-[2svh] error">
-            <%= message %>
+      <% elsif flash_type == "alert" %>
+        <div class="flex justify-center">
+          <div class="flex justify-center items-center bg-white bg-opacity-80 h-[8svh] px-4 fixed w-screen sm:w-[640px]">
+            <div class="p-[2svh] error">
+              <%= message %>
+            </div>
           </div>
         </div>
-      </div>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
   <meta name="keyword" content="えらすぎ, 褒められる, 褒める, えらい, ポジティブ, フィードバック, コミュニティ, モチベーション, やる気, Ruby, Rails, Rails 7, Hotwire, Swiper, Konva">
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="https://erasugi.onrender.com/"/>
-  <meta property="og:image" content="<%= image_url('ogp.png')%>"/>
+  <meta property="og:image" content="<%= image_url('ogp.png') %>"/>
   <meta property="og:site_name" content="えらすぎ"/>
   <meta property="og:description" content="えらすぎは匿名で気軽に褒めたり褒められたりできる無料のWebサービスです。"/>
   <meta name="twitter:card" content="summary_large_image"/>
@@ -29,17 +29,15 @@
     <%= render "layouts/header" %>
   </header>
   <div id="container" class="absolute"></div>
-    <main class="w-full sm:w-[640px]">
-      <div id="flash">
-        <%= render "layouts/flash" %>
-      </div>
-      <div class="h-[80svh]">
-        <%= yield %>
-      </div>
-    </main>
-    <footer class="h-[10svh] flex items-center justify-center fixed bottom-0 z-50 bg-white bg-opacity-80 w-screen sm:w-[640px]">
-      <%= render "layouts/footer" %>
-    </footer>
-  </div>
+  <main class="w-full sm:w-[640px]">
+    <%= render "layouts/flash" %>
+    <div class="h-[80svh]">
+      <%= yield %>
+    </div>
+  </main>
+  <footer class="h-[10svh] flex items-center justify-center fixed bottom-0 z-50 bg-white bg-opacity-80 w-screen sm:w-[640px]">
+    <%= render "layouts/footer" %>
+  </footer>
+</div>
 </body>
 </html>


### PR DESCRIPTION
# Issue
- #339

# 概要
clipboard_controller.jsに関して以下の修正をした。
- フラッシュメッセージを表示する部分はflash_controller.jsに分けた。
コントローラー間の呼び出しの参考: [Cross\-Controller Coordination With Events](https://stimulus.hotwired.dev/reference/controllers#cross-controller-coordination-with-events)
- getElementByIdで取得していた部分をtargetで取得するようにした。
- スペルミスで呼ばれていなかったremoval_controller.jsを呼ばれるようにした。

