### PR TITLE
存在しないpostを指定したら404エラーになるように変更

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,7 +6,7 @@ class PostsController < PublicApplicationController
   end
 
   def show
-    @post = Post.find_by(public_uid: params[:id])
+    @post = Post.find_by!(public_uid: params[:id])
   end
 
   def new


### PR DESCRIPTION
# Issue
- #353 

# 概要
存在しないpostを指定したら404エラーになるように変更した。