### PR TITLE
投稿一覧の表示順がランダムにならないバグを修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@
 
 class PostsController < PublicApplicationController
   def index
-    @posts = Post.order(created_at: :desc).limit(100).order('RANDOM()').limit(10)
+    @posts = Post.where(id: Post.order(created_at: :desc).limit(100)).order('RANDOM()').limit(10)
   end
 
   def show


### PR DESCRIPTION
# Issue
- #364 

# 概要
投稿一覧の表示順がランダムにならないバグを修正